### PR TITLE
Wrong extend

### DIFF
--- a/resources/views/tenant/account/profile.blade.php
+++ b/resources/views/tenant/account/profile.blade.php
@@ -1,4 +1,4 @@
-@extends('tenant.app')
+@extends('layouts.app')
 
 @section('content')
     <div class="container">


### PR DESCRIPTION
Previously it tried to extend @extends('tenant.app')  which caused an error `[Vue warn]: Cannot find element: #app`
Screenshot: http://gruz.ml/images/x/2019_01_30_14_09_31_eb.png